### PR TITLE
Add support for tel: links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Converts `f` to a floating-point number. `f` is first coerced to a floating-poin
 
 ### `launder.url(s, def)`
 
-Attempts to ensure that `s` is a valid URL. This method allows only the `http:`, `https:`, `ftp:` and `mailto:` URL schemes, but does allow relative URLs, and attempts to automatically fix common user mistakes such as typing:
+Attempts to ensure that `s` is a valid URL. This method allows only the `http:`, `https:`, `ftp:`, `mailto:`, and `tel:` URL schemes, but does allow relative URLs, and attempts to automatically fix common user mistakes such as typing:
 
 ```
 www.mycompany.com

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Pads the specified integer with leading zeroes to ensure it has at least `places
 
 ## Changelog
 
+1.4.0: `tel:` urls are now accepted.
+
 1.3.0: `booleanOrNull` accepts the string `'null'` as a synonym for `null`. Note that `'any'` was already accepted. `'null'` can be an attractive choice when the user will not see it in the query string and conflict with other uses of `'any'` is a concern.
 
 1.2.0: `idRegExp` option may be passed to change the rules for `launder.id`.

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function(options) {
     return s;
 
     function fixUrl(href) {
-      if (href.match(/^(((https?|ftp):\/\/)|mailto:|#|([^/.]+)?\/|[^/.]+$)/)) {
+      if (href.match(/^(((https?|ftp|tel):\/\/)|mailto:|#|([^/.]+)?\/|[^/.]+$)/)) {
         // All good - no change required
         return href;
       } else if (href.match(/^[^/.]+\.[^/.]+/)) {
@@ -137,7 +137,7 @@ module.exports = function(options) {
         return href;
       }
       var scheme = matches[1].toLowerCase();
-      return (!_.contains([ 'http', 'https', 'ftp', 'mailto' ], scheme)) ? true : href;
+      return (!_.contains([ 'http', 'https', 'ftp', 'mailto', 'tel' ], scheme)) ? true : href;
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launder",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A sanitize module for the people. Built for ApostropheCMS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Found this as a result of IA being unable to add `tel:` links to `url` schema fields.

My change on line 112 seems unnecessary/not helping but I'm not sure what/if change is needed there.